### PR TITLE
Fix HelperController to inherit from UmbracoAuthorizedController

### DIFF
--- a/Src/Lecoati.LeBlender.Extension/Controllers/HelperController.cs
+++ b/Src/Lecoati.LeBlender.Extension/Controllers/HelperController.cs
@@ -15,65 +15,38 @@ using Umbraco.Web.UI.Pages;
 namespace Lecoati.LeBlender.Extension.Controllers
 {
 
-    public class HelperController : SurfaceController
+    public class HelperController : UmbracoAuthorizedController
     {
-
-        //TODO: move this to a secure API controller 
         [ValidateInput(false)]
         [HttpPost]
         public ActionResult GetPartialViewResultAsHtmlForEditor()
         {
-
-            umbraco.BusinessLogic.User u = umbraco.helper.GetCurrentUmbracoUser();
-
-            if (u != null)
-            {
-                var modelStr = Request["model"];
-                var view = Request["view"];
-                dynamic model = JsonConvert.DeserializeObject(modelStr);
-                return View("/views/Partials/" + view + ".cshtml", model);
-            }
-            else
-            {
-                return new HttpUnauthorizedResult();
-            }
-
+            var modelStr = Request["model"];
+            var view = Request["view"];
+            dynamic model = JsonConvert.DeserializeObject(modelStr);
+            return View("/views/Partials/" + view + ".cshtml", model);
         }
 
-        //TODO: move this to a secure API controller 
         [ValidateInput(false)]
         [HttpPost]
         public ActionResult SaveEditorConfig()
         {
+            var config = Request["config"];
+            var configPath = Request["configPath"];
 
-            umbraco.BusinessLogic.User u = umbraco.helper.GetCurrentUmbracoUser();
-
-            if (u != null)
+            // Update
+            using (System.IO.StreamWriter file = new System.IO.StreamWriter(System.Web.HttpContext.Current.Server.MapPath(configPath)))
             {
-
-                var config = Request["config"];
-                var configPath = Request["configPath"];
-
-                // Update
-                using (System.IO.StreamWriter file = new System.IO.StreamWriter(System.Web.HttpContext.Current.Server.MapPath(configPath)))
-                {
-                    file.Write(config);
-                }
-
-                // Refrech GridConfig for next use
-                HttpContext.Cache.Remove("LeBlenderControllers");
-                HttpContext.Cache.Remove("LeBlenderGridEditorsList");
-                ApplicationContext.ApplicationCache.ClearCacheByKeySearch("LEBLENDEREDITOR");
-                ApplicationContext.ApplicationCache.RuntimeCache.ClearCacheItem(typeof(BackOfficeController) + "GetGridConfig");
-
-                return Json(new { Message = "Saved" }); ;
-
-            }
-            else
-            {
-                return new HttpUnauthorizedResult();
+                file.Write(config);
             }
 
+            // Refrech GridConfig for next use
+            HttpContext.Cache.Remove("LeBlenderControllers");
+            HttpContext.Cache.Remove("LeBlenderGridEditorsList");
+            ApplicationContext.ApplicationCache.ClearCacheByKeySearch("LEBLENDEREDITOR");
+            ApplicationContext.ApplicationCache.RuntimeCache.ClearCacheItem(typeof(BackOfficeController) + "GetGridConfig");
+
+            return Json(new { Message = "Saved" });
         }
 
     }

--- a/Src/Lecoati.LeBlender.Extension/Events/UmbracoEvents.cs
+++ b/Src/Lecoati.LeBlender.Extension/Events/UmbracoEvents.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Web.Mvc;
+using System.Web.Routing;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Logging;
@@ -17,6 +19,20 @@ namespace Lecoati.LeBlender.Extension.Events
 {
     public class UmbracoEvents : ApplicationEventHandler
     {
+
+        protected override void ApplicationInitialized(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            base.ApplicationInitialized(umbracoApplication, applicationContext);
+
+            RouteTable.Routes.MapRoute(
+                "leblender",
+                "umbraco/backoffice/leblender/helper/{action}",
+                new
+                {
+                    controller = "Helper",
+                }
+            );
+        }
 
         protected override void ApplicationStarting(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/common/services/requesthelper.service.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/common/services/requesthelper.service.js
@@ -11,7 +11,7 @@
             GetPartialViewResultAsHtmlForEditor: function (control) {
 
                 var view = "grid/editors/base";
-                var url = "/umbraco/surface/Helper/GetPartialViewResultAsHtmlForEditor";
+                var url = "/umbraco/backoffice/leblender/Helper/GetPartialViewResultAsHtmlForEditor";
                 var resultParameters = { model: angular.toJson(control, false), view: view, id: $routeParams.id, doctype: $routeParams.doctype };
 
                 //$http.defaults.headers.post["Content-Type"] = "application/x-www-form-urlencoded";

--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/common/services/requesthelper.service.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/common/services/requesthelper.service.js
@@ -46,7 +46,7 @@
             /*********************/
             setGridEditors: function (data) {
 
-                var url = "/umbraco/surface/Helper/SaveEditorConfig";
+                var url = "/umbraco/backoffice/leblender/Helper/SaveEditorConfig";
                 var resultParameters = { config: JSON.stringify(data, null, 4), configPath: configPath };
 
                 //$http.defaults.headers.post["Content-Type"] = "application/x-www-form-urlencoded";


### PR DESCRIPTION
Hi! Thanks for a great package  :+1:

After updating to from Umbraco 7.2.6 to 7.2.7 I started to get 404 errors like this in the backoffice:

![2015-07-16_12h21_13](https://cloud.githubusercontent.com/assets/359614/8720907/3e379626-2bb6-11e5-87ea-447e97465edc.png)

After a bit of research I found out that the cause seems to be that `SurfaceController`'s are not indended to be used in the backoffice. And the fix is to make `HelperController` inherit from `UmbracoAuthorizedController` (http://issues.umbraco.org/issue/U4-4990).

After these changes, LeBlender is up and running in the backoffice once again :)

/ Regin