### PR TITLE
Fix null reference exception if property doesn't exist

### DIFF
--- a/Src/Lecoati.LeBlender.Extension/Models/LeBlenderValue.cs
+++ b/Src/Lecoati.LeBlender.Extension/Models/LeBlenderValue.cs
@@ -25,18 +25,17 @@ namespace Lecoati.LeBlender.Extension.Models
         {
             var property = GetProperty(propertyAlias);
 
-            //******
+            if (IsEmptyProperty(property))
+            {
+                return default(T);
+            }
+
             if (property.Value is long)
             {
                 int newValue;
                 if (Int32.TryParse(property.Value.ToString(), out newValue)) {
                     property.Value = newValue;
                 }
-            }
-
-            if (IsEmptyProperty(property))
-            {
-                return default(T);
             }
 
             return property.GetValue<T>();


### PR DESCRIPTION
If calling e.g. `item.GetValue("non-existing-property-alias")` then LeBlender throws a null reference exception. I've reordered a bit of code that should solve this issue :)

/ Regin