### PR TITLE
Update LeBlenderModel.cs

### DIFF
--- a/Src/Lecoati.LeBlender.Extension/Models/LeBlenderModel.cs
+++ b/Src/Lecoati.LeBlender.Extension/Models/LeBlenderModel.cs
@@ -7,9 +7,14 @@ using System.Web;
 namespace Lecoati.LeBlender.Extension.Models
 {
     [JsonObject]
-    public class LeBlenderModel
-    {
+    public class LeBlenderModel :  RenderModel {
+        public LeBlenderModel() : this(new UmbracoHelper(UmbracoContext.Current).TypedContent(UmbracoContext.Current.PageId)) { }
+        public LeBlenderModel(IPublishedContent content, CultureInfo culture) : base(content, culture) { }
+        public LeBlenderModel(IPublishedContent content) : base(content) { }
+
         [JsonProperty("value")]
         public IEnumerable<LeBlenderValue> Items { get; set; }
+
+        public IPublishedContent Content { get; private set; }
     }
 }


### PR DESCRIPTION
Fixes "dictionary requires a model item of type 'Umbraco.Web.Models.RenderModel'" bug in Umbraco 7.3.