### PR TITLE
Fix issue with dependency handler and use strict

### DIFF
--- a/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.controller.js
+++ b/Src/Lecoati.LeBlender.Ui/App_Plugins/LeBlender/editors/leblendereditor/dialogs/parameterconfig.controller.js
@@ -64,7 +64,7 @@
         };
 
         $scope.add = function () {
-            newItem = {};
+            var newItem = {};
             _.each($scope.config.editors, function (editor, editorIndex) {
     	        var newProperty = {
     	            value: null,


### PR DESCRIPTION
Experienced the same problem as reported here and the proposed fix worked for me as well.

https://our.umbraco.org/projects/backoffice-extensions/leblender/bug-reports/81291-leblender-controllers-not-compatable-with-use-strict-javascript-mode