### PR TITLE
Fix #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@
 /Src/Lecoati.LeBlender.Extension/App_Data
 /Src/Lecoati.LeBlender.Ui/App_Plugins/Doc_Type_Grid
 /Src/Lecoati.LeBlender.Ui/App_Plugins/DocTypeGridEditor
+/.vs/config/applicationhost.config

--- a/Src/Lecoati.LeBlender.Extension/Controllers/LeBlenderEditorManagerTreeController.cs
+++ b/Src/Lecoati.LeBlender.Extension/Controllers/LeBlenderEditorManagerTreeController.cs
@@ -9,6 +9,7 @@ using System.Web.Mvc;
 using umbraco;
 using umbraco.BusinessLogic.Actions;
 using Umbraco.Core;
+using Umbraco.Core.Configuration.Grid;
 using Umbraco.Web.Models.Trees;
 using Umbraco.Web.Mvc;
 using Umbraco.Web.Trees;
@@ -45,7 +46,7 @@ namespace Lecoati.LeBlender.Extension.Controllers
             var nodes = new TreeNodeCollection();
             if (id == "-1")
             {
-                IList<GridEditor> editors = Helper.GetLeBlenderGridEditors(false).ToList();
+                IList<IGridEditorConfig> editors = Helper.GetLeBlenderGridEditors(false).ToList();
                 foreach (var editor in editors)
                 {
                     nodes.Add(this.CreateTreeNode(editor.Alias, id, queryStrings, editor.Name, editor.Icon, false));

--- a/Src/Lecoati.LeBlender.Extension/Controllers/PropertyGridEditorController.cs
+++ b/Src/Lecoati.LeBlender.Extension/Controllers/PropertyGridEditorController.cs
@@ -57,12 +57,6 @@ namespace Lecoati.LeBlender.Extension.Controllers
         internal IEnumerable<PackageManifest> GetManifests()
         {
             var plugins = new DirectoryInfo(HttpContext.Current.Server.MapPath("~/App_Plugins"));
-            //return _cache.GetCacheItem<IEnumerable<PackageManifest>>("LeBlenderGetManifests", () =>
-            //{
-            //    //get all Manifest.js files in the appropriate folders
-            //    var manifestFileContents = GetAllManifestFileContents(plugins);
-            //    return CreateManifests(manifestFileContents.ToArray());
-            //}, new TimeSpan(0, 10, 0));
 
             var manifestFileContents = GetAllManifestFileContents(plugins);
             return CreateManifests(manifestFileContents.ToArray());

--- a/Src/Lecoati.LeBlender.Extension/LeBlenderHelper.cs
+++ b/Src/Lecoati.LeBlender.Extension/LeBlenderHelper.cs
@@ -4,15 +4,20 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Web;
 using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Configuration.Grid;
+using Umbraco.Core.IO;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
 using Umbraco.Web.Editors;
+using Umbraco.Web.Mvc;
 
 namespace Lecoati.LeBlender.Extension
 {
@@ -72,25 +77,29 @@ namespace Lecoati.LeBlender.Extension
         /// </summary>
         /// <param name="LeBlenderEditorAlias"></param>
         /// <returns></returns>
-        public static int GetCacheExpiration(String LeBlenderEditorAlias) { 
+        public static int GetCacheExpiration(String LeBlenderEditorAlias)
+        {
+            // Set default expiration.
+            var expiration = 0;
 
-            var result = 0;
-
-            try 
+            // Try to get expiration if specified.
+            try
             {
+                // Load editor for this type.
                 var editor = GetLeBlenderGridEditors(true).FirstOrDefault(r => r.Alias == LeBlenderEditorAlias);
+
+                // Attempt to load expiration data for this type.
                 if (editor.Config.ContainsKey("expiration") && editor.Config["expiration"] != null)
                 {
-                    int.TryParse(editor.Config["expiration"].ToString(), out result);
+                    int.TryParse(editor.Config["expiration"].ToString(), out expiration);
                 }
             }
             catch (Exception ex)
             {
-                LogHelper.Error<Helper>("Could not read expiration datas", ex);
+                LogHelper.Error<Helper>("Could not read editor expiration data from configuration.", ex);
             }
 
-            return result;
-
+            return expiration;
         }
 
         #region internal
@@ -99,43 +108,39 @@ namespace Lecoati.LeBlender.Extension
         /// Get and cache LeBlender Grid Editor 
         /// </summary>
         /// <returns></returns>
-        internal static IEnumerable<GridEditor> GetLeBlenderGridEditors(bool onlyLeBlenderEditor) 
+        internal static IEnumerable<IGridEditorConfig> GetLeBlenderGridEditors(bool onlyLeBlenderEditor)
         {
-            
-            Func<List<GridEditor>> getResult = () =>
+            Func<IEnumerable<IGridEditorConfig>> getResult = () =>
             {
-                var editors = new List<GridEditor>();
-                var gridConfig = HttpContext.Current.Server.MapPath("~/Config/grid.editors.config.js");
-                if (System.IO.File.Exists(gridConfig))
-                {
-                    try
-                    {
-                        var arr = JArray.Parse(System.IO.File.ReadAllText(gridConfig));
-                        var parsed = JsonConvert.DeserializeObject<IEnumerable<GridEditor>>(arr.ToString()); ;
-                        editors.AddRange(parsed);
+                // Get Umbraco grid editor config including manifests
+                var gridConfig = UmbracoConfig.For.GridConfig(
+                    UmbracoContext.Current.Application.ProfilingLogger.Logger,
+                    UmbracoContext.Current.Application.ApplicationCache.RuntimeCache,
+                    new DirectoryInfo(UmbracoContext.Current.HttpContext.Server.MapPath(SystemDirectories.AppPlugins)),
+                    new DirectoryInfo(UmbracoContext.Current.HttpContext.Server.MapPath(SystemDirectories.Config)),
+                    UmbracoContext.Current.HttpContext.IsDebuggingEnabled);
 
-                        if (onlyLeBlenderEditor)
-                        {
-                            editors = editors.Where(r => r.View.Equals("/App_Plugins/LeBlender/core/LeBlendereditor.html", StringComparison.InvariantCultureIgnoreCase) ||
-                                r.View.Equals("/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html", StringComparison.InvariantCultureIgnoreCase)).ToList();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        LogHelper.Error<Helper>("Could not parse the contents of grid.editors.config.js into a JSON array", ex);
-                    }
+                // Get grid editors
+                var gridEditors = gridConfig.EditorsConfig.Editors;
+
+                // Filter to only display LeBlender editors if needed
+                if (onlyLeBlenderEditor)
+                {
+                    gridEditors = gridEditors.Where(x => x.View.Equals("/App_Plugins/LeBlender/core/LeBlendereditor.html", StringComparison.InvariantCultureIgnoreCase) ||
+                                                         x.View.Equals("/App_Plugins/LeBlender/editors/leblendereditor/LeBlendereditor.html", StringComparison.InvariantCultureIgnoreCase));
                 }
-                return editors;
+
+                return gridEditors.ToList();
             };
 
-            var result = (List<GridEditor>)HttpContext.Current.Cache["LeBlenderGridEditorsList"];
+            var result = (IEnumerable<IGridEditorConfig>)HttpContext.Current.Cache["LeBlenderGridEditorsList"];
             if (result == null || !onlyLeBlenderEditor)
-            { 
+            {
                 result = getResult();
                 HttpContext.Current.Cache.Add("LeBlenderGridEditorsList", result, null, DateTime.Now.AddDays(1), System.Web.Caching.Cache.NoSlidingExpiration, System.Web.Caching.CacheItemPriority.High, null);
             }
 
-            return (IEnumerable<GridEditor>)result;
+            return result;
 
         }
 
@@ -143,7 +148,8 @@ namespace Lecoati.LeBlender.Extension
         /// Get and cache LeBlender Controllers
         /// </summary>
         /// <returns></returns>
-        internal static IEnumerable<Type> GetLeBlenderControllers() {
+        internal static IEnumerable<Type> GetLeBlenderControllers()
+        {
 
             Func<List<Type>> getResult = () =>
             {
@@ -173,7 +179,8 @@ namespace Lecoati.LeBlender.Extension
             Type result = null;
             var controllers = GetLeBlenderControllers();
 
-            if (controllers.Any()) {
+            if (controllers.Any())
+            {
                 var controllersFilter = controllers.Where(t => t.Name.Equals(editorAlias + "Controller", StringComparison.InvariantCultureIgnoreCase));
                 result = controllersFilter.Any() ? controllersFilter.First() : null;
             }
@@ -185,7 +192,8 @@ namespace Lecoati.LeBlender.Extension
         /// </summary>
         /// <param name="guid"></param>
         /// <returns></returns>
-        internal static string BuildCacheKey(string guid) {
+        internal static string BuildCacheKey(string guid)
+        {
             var cacheKey = new StringBuilder();
             cacheKey.Append("LEBLENDEREDITOR");
             cacheKey.Append(guid);

--- a/Src/Lecoati.LeBlender.Extension/Lecoati.leblender.Extension.csproj
+++ b/Src/Lecoati.LeBlender.Extension/Lecoati.leblender.Extension.csproj
@@ -8,7 +8,7 @@
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{C1A88503-8062-4992-85AB-8367B2D38630}</ProjectGuid>
-    <ProjectTypeGuids>{E3E379DF-F4C6-4180-9B81-6769533ABE47};{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
+    <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Lecoati.LeBlender.Extension</RootNamespace>
@@ -303,6 +303,7 @@
   <ItemGroup>
     <Compile Include="Controllers\LeBlenderController.cs" />
     <Compile Include="Controllers\LeBlenderEditorManagerTreeController.cs" />
+    <Compile Include="Models\GridEditor.cs" />
     <Compile Include="Models\GridEditorsConfig\Editor.cs" />
     <Compile Include="Models\GridEditorsConfig\GridEditorsConfig.cs" />
     <Compile Include="Models\Manifest\PackageManifest.cs" />
@@ -316,7 +317,6 @@
     <Compile Include="Events\UmbracoEvents.cs" />
     <Compile Include="JSonPresentationFormatter.cs" />
     <Compile Include="LeBlenderPartialCacher.cs" />
-    <Compile Include="Models\GridEditor.cs" />
     <Compile Include="Models\LeBlenderValue.cs" />
     <Compile Include="Models\LeBlenderModelMatchingConverter.cs" />
     <Compile Include="Models\LeBlenderPropertyModel.cs" />

--- a/Src/Lecoati.LeBlender.Extension/Models/GridEditor.cs
+++ b/Src/Lecoati.LeBlender.Extension/Models/GridEditor.cs
@@ -6,8 +6,8 @@ using System.Web;
 
 namespace Lecoati.LeBlender.Extension.Models
 {
-
-    internal class GridEditor
+    [Obsolete("GridEditor is deprecated. Use Umbraco.Core.Configuration.Grid.IGridEditorConfig instead.")]
+    internal class GridEditor : Umbraco.Core.Configuration.Grid.IGridEditorConfig
     {
 
         public GridEditor()

--- a/Src/Lecoati.LeBlender.Extension/Properties/AssemblyInfo.cs
+++ b/Src/Lecoati.LeBlender.Extension/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers 
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.8.3")]
-[assembly: AssemblyFileVersion("1.0.8.3")]
+[assembly: AssemblyVersion("1.0.8.5")]
+[assembly: AssemblyFileVersion("1.0.8.5")]


### PR DESCRIPTION
This pull request fixes Issue #64 which happens when editor types are defined in package manifests.

Switch to use UmbracoConfig method to load grid editors rather than just reading from grid editors config file. This handles editors coming from manifest files as well.

Also switched to use Umbraco IGridEditorConfig instead of GridEditor class, which I've marked as deprecated. The custom class is redundant.