### PR TITLE
Update readme for v1.0.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Change your BlenderModel references to LeBlenderModel
 Save and publish the content which uses the LeBlender editor
 
 ### Change logs
- 
+
+#### 1.0.8.4
+- Fix null reference exception if property doesn't exist
+
 #### 1.0.8
 - Important Bug fixed: LeBlender Helper surfase controller return 404 since umb 7.2.7+
 - Numeric property returns 0


### PR DESCRIPTION
Issue which was fixed in v1.0.8.4, where it returned a null exception if the property didn't exist
https://github.com/Lecoati/LeBlender/commit/e41f9459f4da63642f9cddfd7174fcceeb8ecfd4

Also a longer thread on Our here about the issue: https://our.umbraco.org/projects/backoffice-extensions/leblender/bug-reports/75026-render-in-backend-not-working-after-upgrading-to-74